### PR TITLE
Update isect depedency to fix vite/esbuild package resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "three-svg-renderer",
-  "version": "0.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "three-svg-renderer",
-      "version": "0.0.2",
+      "version": "1.0.3",
+      "license": "GPLV3",
       "dependencies": {
         "@svgdotjs/svg.js": "^3.1.2",
         "@svgdotjs/svg.topath.js": "^2.0.3",
         "arrangement-2d-js": "github:LokiResearch/arrangement-2d-js",
         "fast-triangle-triangle-intersection": "^1.0.7",
         "flatbush": "^4.0.0",
-        "isect": "^3.0.0",
+        "isect": "^3.0.1",
         "opencv-ts": "^1.3.6",
         "three-mesh-bvh": "^0.5.14",
         "three-mesh-halfedge": "^1.0.3",
@@ -3409,9 +3410,9 @@
       }
     },
     "node_modules/isect": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isect/-/isect-3.0.0.tgz",
-      "integrity": "sha512-HEz/cX8Xp4ZMJ4Q7vzEVayTL/egY1D7dNyV0x88gJso7T09hIUT+njcnCMVtGWNcGbVrY692YgFrUK56TP/eWA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isect/-/isect-3.0.1.tgz",
+      "integrity": "sha512-06Cw/P9B9xs7C6cOZXX00ySvHNO3XVosoljHYHpsaLYdII3b+PbAvk55R2QNiwTWsSwWyMyqf87lgtCy4Ad4gA==",
       "dependencies": {
         "splaytree": "^2.0.2"
       }
@@ -8440,9 +8441,9 @@
       "dev": true
     },
     "isect": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isect/-/isect-3.0.0.tgz",
-      "integrity": "sha512-HEz/cX8Xp4ZMJ4Q7vzEVayTL/egY1D7dNyV0x88gJso7T09hIUT+njcnCMVtGWNcGbVrY692YgFrUK56TP/eWA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isect/-/isect-3.0.1.tgz",
+      "integrity": "sha512-06Cw/P9B9xs7C6cOZXX00ySvHNO3XVosoljHYHpsaLYdII3b+PbAvk55R2QNiwTWsSwWyMyqf87lgtCy4Ad4gA==",
       "requires": {
         "splaytree": "^2.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "arrangement-2d-js": "github:LokiResearch/arrangement-2d-js",
     "fast-triangle-triangle-intersection": "^1.0.7",
     "flatbush": "^4.0.0",
-    "isect": "^3.0.0",
+    "isect": "^3.0.1",
     "opencv-ts": "^1.3.6",
     "three-mesh-bvh": "^0.5.14",
     "three-mesh-halfedge": "^1.0.3",


### PR DESCRIPTION
vite/esbuild breaks when installing `three-svg-renderer` via npm. The issue came from isect dependency declaration, which [has been patched](https://github.com/anvaka/isect/pull/14)

